### PR TITLE
Fix included in gem files in gemspec

### DIFF
--- a/animate-rails.gemspec
+++ b/animate-rails.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.description = 'animate.css for rails'
   s.license     = 'MIT'
 
-  s.files = Dir['{lib,vendor}/**/*'] + ['MIT-LICENSE', 'Rakefile', 'README.md']
+  s.files = Dir['{lib,app}/**/*'] + ['MIT-LICENSE', 'Rakefile', 'README.md']
   s.add_dependency 'rails'
 end


### PR DESCRIPTION
Commit 7829692d181a9e1114e4f86878890078a1711e88 breaks internal gem file structure, app dir doesn't include into final gem. 
